### PR TITLE
Add extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,10 @@
     "replace": {
         "brainappeal/campus_events_connector": "self.version",
         "typo3-ter/campus_events_connector": "self.version"
+    },
+    "extra": {
+	    "typo3/cms": {
+	        "extension-key": "campus_events_connector"
+	    }
     }
 }


### PR DESCRIPTION
Fix for composer based installations:

The TYPO3 extension package "brainappeal/campus_events_connector", does not define an extension key in its composer.json. Please report this to the author of this package. Specifying the extension key will be mandatory in future ver
sions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
